### PR TITLE
This fixes the issue I opened. If there is a better way please let me know.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ bin
 obj
 *.user
 *.suo
-
+build
+src/Hiro-vs2008/*
+*.sdps
+*.log

--- a/src/Core/Resolvers/ConstructorResolver.cs
+++ b/src/Core/Resolvers/ConstructorResolver.cs
@@ -31,13 +31,19 @@ namespace Hiro.Resolvers
             }
 
             var bestParameterCount = 0;
+            var index=-1;
+            var missingIndex =0;
             foreach (var constructor in constructors)
             {
+            	index++;
                 var missingDependencies = constructor.GetMissingDependencies(container);
                 var missingItems = new List<IDependency>(missingDependencies);
-                var hasMissingDependencies = missingDependencies == null || missingItems.Count > 0;
+                var hasMissingDependencies = missingDependencies == null || missingItems.Count > 0;                
                 if (hasMissingDependencies)
-                    continue;
+                {
+                	missingIndex = index;
+                	continue;
+                }
 
                 var targetConstructor = constructor.Target;
                 var parameters = targetConstructor.GetParameters();
@@ -49,8 +55,8 @@ namespace Hiro.Resolvers
                     bestParameterCount = parameterCount;
                 }
             }
-
-            return result;
+            if(constructors.Count==0) return null;
+            return result??constructors[missingIndex];
         }
 
         /// <summary>

--- a/src/SampleAssembly/Delegates.cs
+++ b/src/SampleAssembly/Delegates.cs
@@ -1,0 +1,16 @@
+﻿/*
+ * Created by SharpDevelop.
+ * User: jcastro
+ * Date: 2011-05-24
+ * Time: 4:34 PM
+ * 
+ * To change this template use Tools | Options | Coding | Edit Standard Headers.
+ */
+using System;
+
+namespace SampleAssembly
+{
+	//BUG: an assembly with a public delegate will generate a ConstructorNotFoundException at container compile time.
+	public delegate void Proc();
+}
+

--- a/src/SampleAssembly/IMissing.cs
+++ b/src/SampleAssembly/IMissing.cs
@@ -1,0 +1,20 @@
+﻿/*
+ * Created by SharpDevelop.
+ * User: jcastro
+ * Date: 2011-05-24
+ * Time: 4:21 PM
+ * 
+ * To change this template use Tools | Options | Coding | Edit Standard Headers.
+ */
+using System;
+
+namespace SampleAssembly
+{
+	/// <summary>
+	/// This interface is supposed to be implemented in a 'destination' assembly different from this one
+	/// </summary>
+	public interface IMissing
+	{
+		string TypeName{ get;}
+	}
+}

--- a/src/SampleAssembly/SampleAssembly.csproj
+++ b/src/SampleAssembly/SampleAssembly.csproj
@@ -50,6 +50,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BazImplementations.cs" />
+    <Compile Include="Delegates.cs" />
+    <Compile Include="IMissing.cs" />
+    <Compile Include="SampleMissingDependency.cs" />
     <Compile Include="DbConTest.cs" />
     <Compile Include="IBaz.cs" />
     <Compile Include="IDbConnection.cs" />

--- a/src/SampleAssembly/SampleMissingDependency.cs
+++ b/src/SampleAssembly/SampleMissingDependency.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Created by SharpDevelop.
+ * User: jcastro
+ * Date: 2011-05-24
+ * Time: 4:21 PM
+ * 
+ * To change this template use Tools | Options | Coding | Edit Standard Headers.
+ */
+using System;
+
+namespace SampleAssembly
+{
+	
+	
+
+	/// <summary>
+	/// This class implements a service, however is intended to be derived from to provide
+	/// another constructor signature or explicitly created. It is inteded to have missing 
+	/// dependencies	
+	/// </summary>
+	public class SampleMissingDependency:IMissing
+	{
+		private System.Type _type;
+		/// <summary>
+		/// The constructor for the missing dependency
+		/// </summary>
+		/// <param name="type">The missing dependency</param>
+		public SampleMissingDependency(System.Type type)
+		{
+			_type=type;
+		}
+		public string TypeName
+		{
+			get
+			{
+				return _type.Name;
+			}
+		}
+	}
+}

--- a/src/UnitTests/BugFixes/BugFixTests.cs
+++ b/src/UnitTests/BugFixes/BugFixTests.cs
@@ -9,6 +9,7 @@ using Mono.Cecil;
 using NUnit.Framework;
 using Hiro.Loaders;
 using PaulBenchmark;
+using SampleAssembly;
 
 namespace Hiro.UnitTests.BugFixes
 {
@@ -69,6 +70,30 @@ namespace Hiro.UnitTests.BugFixes
                 var driver = currentInstance.Driver;
                 Assert.AreSame(driver, person);
             }
+        }
+        
+        [Test]
+        public void ShouldBeAbleToLoadSampleAssemblyWithoutRunningIntoConstructorNotFoundException()
+        {
+        	var loader = new DependencyMapLoader();
+            var map = loader.LoadFromBaseDirectory("SampleAssembly.dll");
+
+            var container = map.CreateContainer();
+            var result = container.GetInstance<object>("Sample");
+
+            Assert.AreEqual(42, result);
+        }
+        
+        [Test]
+        public void ShouldReturnNullWhenTryingToInstantiateAnIncompleteDependency()
+        {
+        	var loader = new DependencyMapLoader();
+            var map = loader.LoadFromBaseDirectory("SampleAssembly.dll");
+
+            var container = map.CreateContainer();
+            var result = container.GetInstance<IMissing>();
+            
+            Assert.IsNull(result);
         }
 
         [Test]


### PR DESCRIPTION
Issue 2: Fixed bug Including an assembly with a delegate type or an Incomplete Service implementation
Added classes which generate the failure
Added classes and tests that check the specific failure
Fixed ConstructorResolver as simply as possible, it allways returns a constructor
